### PR TITLE
Fix sh to start conda without error

### DIFF
--- a/anaconda/entrypoint.sh
+++ b/anaconda/entrypoint.sh
@@ -1,5 +1,5 @@
-apt update -y
-apt install -y python3-dev python3-pip libpq-dev gcc
-pip install psycopg2
-conda install jupyter -y --quiet
+apt update -y &&
+apt install -y python3-dev python3-pip libpq-dev gcc &&
+pip install psycopg2 &&
+conda install jupyter -y --quiet &&
 jupyter notebook --notebook-dir=/opt/notebooks --ip='*' --port=30888 --no-browser --allow-root


### PR DESCRIPTION
Fix errors like this: 
```
Downloading psycopg2-2.9.3.tar.gz (380 kB)
workshop_sql_optimization-anaconda-1  |     ERROR: Command errored out with exit status 1:
```